### PR TITLE
enh: add compatibility with zfit 0.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - matplotlib
   - pip:
     - .
-    - zfit =>0.6.4
+    - zfit >=0.6.4

--- a/environment.yml
+++ b/environment.yml
@@ -6,11 +6,11 @@ dependencies:
   - numpy
   - scipy
   - iminuit
-  - tensorflow>=2.0
+  - tensorflow>=2.4
   - tensorflow-probability
   #- zfit
   - asdf
   - matplotlib
   - pip:
     - .
-    - zfit
+    - zfit =>0.6.4

--- a/src/hepstats/hypotests/calculators/asymptotic_calculator.py
+++ b/src/hepstats/hypotests/calculators/asymptotic_calculator.py
@@ -116,7 +116,7 @@ class AsymptoticCalculator(BaseCalculator):
             data = self.data
             minimizer = self.minimizer
             oldverbose = minimizer.verbosity
-            minimizer.verbosity = 5
+            minimizer.verbosity = 0
 
             poiparam = poi.parameter
             poivalue = poi.value

--- a/src/hepstats/hypotests/hypotests_object.py
+++ b/src/hepstats/hypotests/hypotests_object.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 
 from ..utils.fit.api_check import is_valid_loss, is_valid_fitresult, is_valid_minimizer
 from ..utils.fit.api_check import is_valid_data, is_valid_pdf
@@ -157,8 +158,18 @@ class HypotestsObject(object):
             for d, w in zip(data, weights):
                 d.set_weights(w)
 
-        loss = type(self.loss)(model=model, data=data)
-        loss.add_constraints(self.constraints)
+        if hasattr(self.loss, "create_new"):
+            loss = self.loss.create_new(
+                model=model, data=data, constraints=self.constraints
+            )
+        else:
+            warnings.warn(
+                "A loss should have a `create_new` method. If you are using zfit, please make sure to"
+                "upgrade to >= 0.6.3",
+                FutureWarning,
+            )
+            loss = type(self.loss)(model=model, data=data)
+            loss.add_constraints(self.constraints)
 
         return loss
 

--- a/src/hepstats/hypotests/hypotests_object.py
+++ b/src/hepstats/hypotests/hypotests_object.py
@@ -165,7 +165,7 @@ class HypotestsObject(object):
         else:
             warnings.warn(
                 "A loss should have a `create_new` method. If you are using zfit, please make sure to"
-                "upgrade to >= 0.6.3",
+                "upgrade to >= 0.6.4",
                 FutureWarning,
             )
             loss = type(self.loss)(model=model, data=data)

--- a/src/hepstats/utils/fit/api_check.py
+++ b/src/hepstats/utils/fit/api_check.py
@@ -118,7 +118,12 @@ def is_valid_loss(object):
 
     has_get_params = hasattr(object, "get_params")
     has_constraints = hasattr(object, "constraints")
-    has_fit_range = hasattr(object, "fit_range")
+    has_create_new = hasattr(object, "create_new")
+    if not has_create_new:
+        warnings.warn(
+            "Loss should have a `create_new` method.", FutureWarning, stacklevel=3
+        )
+        has_create_new = True  # TODO: allowed now, will be dropped in the future
     all_valid_pdfs = all(is_valid_pdf(m) for m in model)
     all_valid_datasets = all(is_valid_data(d) for d in data)
 
@@ -126,7 +131,7 @@ def is_valid_loss(object):
         all_valid_pdfs
         and all_valid_datasets
         and has_constraints
-        and has_fit_range
+        and has_create_new
         and has_get_params
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-import pytest
 import numpy as np
+import pytest
 
 
 def pytest_addoption(parser):
@@ -27,3 +27,26 @@ def data_gen():
     data2 = np.random.normal(2, 1, size=1000)
     weights = np.random.uniform(1, 2, size=1000)
     return data1, data2, weights
+
+
+# TODO: manually ported, use pre-made: https://github.com/zfit/zfit-development/issues/73
+@pytest.fixture(autouse=True)
+def setup_teardown():
+    import zfit
+
+    old_chunksize = zfit.run.chunking.max_n_points
+    old_active = zfit.run.chunking.active
+
+    yield
+
+    from zfit.core.parameter import ZfitParameterMixin
+
+    ZfitParameterMixin._existing_params.clear()
+
+    from zfit.util.cache import clear_graph_cache
+
+    clear_graph_cache()
+    zfit.run.chunking.active = old_active
+    zfit.run.chunking.max_n_points = old_chunksize
+    zfit.run.set_graph_mode()
+    zfit.run.set_autograd_mode()

--- a/tests/hypotests/test_basetest.py
+++ b/tests/hypotests/test_basetest.py
@@ -2,10 +2,7 @@
 import pytest
 import numpy as np
 import zfit
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
-from zfit.core.loss import UnbinnedNLL
+from zfit.loss import UnbinnedNLL
 from zfit.minimize import Minuit
 
 from hepstats.hypotests.calculators.basecalculator import BaseCalculator

--- a/tests/hypotests/test_calculators.py
+++ b/tests/hypotests/test_calculators.py
@@ -4,10 +4,7 @@ import pytest
 import numpy as np
 
 import zfit
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
-from zfit.core.loss import UnbinnedNLL
+from zfit.loss import UnbinnedNLL
 from zfit.minimize import Minuit
 
 from hepstats.hypotests.calculators.basecalculator import BaseCalculator

--- a/tests/hypotests/test_confidence_intervals.py
+++ b/tests/hypotests/test_confidence_intervals.py
@@ -3,9 +3,6 @@ import pytest
 import numpy as np
 import zfit
 import os
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
 from zfit.loss import ExtendedUnbinnedNLL, UnbinnedNLL
 from zfit.minimize import Minuit
 

--- a/tests/hypotests/test_discovery.py
+++ b/tests/hypotests/test_discovery.py
@@ -3,10 +3,7 @@ import os
 import pytest
 import numpy as np
 import zfit
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
-from zfit.core.loss import ExtendedUnbinnedNLL, UnbinnedNLL
+from zfit.loss import ExtendedUnbinnedNLL, UnbinnedNLL
 from zfit.minimize import Minuit
 
 from zfit.models.dist_tfp import WrapDistribution

--- a/tests/hypotests/test_toysutils.py
+++ b/tests/hypotests/test_toysutils.py
@@ -3,10 +3,7 @@ import pytest
 import numpy as np
 import zfit
 import os
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
-from zfit.core.loss import ExtendedUnbinnedNLL, UnbinnedNLL
+from zfit.loss import ExtendedUnbinnedNLL, UnbinnedNLL
 from zfit.minimize import Minuit
 
 import hepstats

--- a/tests/hypotests/test_upperlimit.py
+++ b/tests/hypotests/test_upperlimit.py
@@ -3,9 +3,6 @@ import pytest
 import numpy as np
 import zfit
 import os
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
 from zfit.loss import ExtendedUnbinnedNLL
 from zfit.minimize import Minuit
 

--- a/tests/splots/test_splots.py
+++ b/tests/splots/test_splots.py
@@ -4,9 +4,6 @@ import pytest
 from scipy.stats import chisquare
 
 import zfit
-from zfit.core.testing import (
-    teardown_function,
-)  # allows redefinition of zfit.Parameter, needed for tests
 from zfit.loss import ExtendedUnbinnedNLL
 from zfit.minimize import Minuit
 


### PR DESCRIPTION
In order to allow a loss to have optimizations in there and for an easier creation of a new loss, added a method that creates a new loss and therefore reduces the reliability on a specific implementation when creating a new loss.

The new method is `create_new`. Added this in the implementation and the interface check