### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - os: windows-latest
             python-version: "3.9"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.9"
           - os: macos-14
             python-version: "3.12"  # old versions not supported


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos