### PR TITLE
Fixing the FrequentistCalculator module

### DIFF
--- a/src/hepstats/hypotests/calculators/frequentist_calculator.py
+++ b/src/hepstats/hypotests/calculators/frequentist_calculator.py
@@ -83,7 +83,7 @@ class FrequentistCalculator(ToysCalculator):
             >>> poialt = POI(mean, 1.2)
             >>> q = calc.qnull(poinull, poialt)
         """
-        toysresults = self.get_toys_null(poinull, poialt, qtilde)
+        toysresults = self.get_toys_null(poinull, poinull, qtilde)
         ret = {}
 
         for p in poinull:

--- a/src/hepstats/hypotests/hypotests_object.py
+++ b/src/hepstats/hypotests/hypotests_object.py
@@ -201,7 +201,6 @@ class ToysObject(HypotestsObject):
 
         >>> sampler = calc.sampler()
         """
-        self.set_params_to_bestfit()
         nevents = []
         for m, d in zip(self.loss.model, self.loss.data):
             nevents_data = get_nevents(d)
@@ -251,8 +250,7 @@ class ToysObject(HypotestsObject):
         Example with `zfit`:
             >>> loss = calc.toys_loss(zfit.Parameter("mean"))
         """
-        if parameter_name not in self._toys_loss:
-            parameter = self.get_parameter(parameter_name)
-            sampler = self.sampler()
-            self._toys_loss[parameter.name] = self.lossbuilder(self.model, sampler)
+        parameter = self.get_parameter(parameter_name)
+        sampler = self.sampler()
+        self._toys_loss[parameter.name] = self.lossbuilder(self.model, sampler)
         return self._toys_loss[parameter_name]

--- a/src/hepstats/hypotests/toyutils.py
+++ b/src/hepstats/hypotests/toyutils.py
@@ -238,9 +238,10 @@ class ToysManager(ToysObject):
         # generate toys from best fit at profile point
         param.set_value(poigen.value)
         is_poi_floating = param.floating
-        param.floating=False
+        param.floating = False
         profile_minimum = minimizer.minimize(loss=self.loss)
-        if not profile_minimum.valid: print(poigen, "PROBLEM: profile fit not valid, toys won't be either")
+        if not profile_minimum.valid:
+            print(poigen, "PROBLEM: profile fit not valid, toys won't be either")
         param.floating = is_poi_floating
 
         toys_loss = self.toys_loss(poigen.name)

--- a/src/hepstats/hypotests/toyutils.py
+++ b/src/hepstats/hypotests/toyutils.py
@@ -232,10 +232,16 @@ class ToysManager(ToysObject):
             poieval: POI values to evaluate the loss function
         """
 
-        self.set_params_to_bestfit()
-
         minimizer = self.minimizer
         param = poigen.parameter
+
+        # generate toys from best fit at profile point
+        param.set_value(poigen.value)
+        is_poi_floating = param.floating
+        param.floating=False
+        profile_minimum = minimizer.minimize(loss=self.loss)
+        if not profile_minimum.valid: print(poigen, "PROBLEM: profile fit not valid, toys won't be either")
+        param.floating = is_poi_floating
 
         toys_loss = self.toys_loss(poigen.name)
         sampler = toys_loss.data


### PR DESCRIPTION
I tried the FrequentistCalculator for limit setting with this nice library, but unfortunately found it creating quite weird results, as also reported in #175. 
So yesterday I threw myself at it and managed to get a working version with some tweaks.
It may not be most elegant python nor do I have the overview whether this fix is not breaking another use case. But it seems to work for me. I attach the script I use for testing (effectively adapted from https://github.com/scikit-hep/hepstats/blob/main/notebooks/hypotests/upperlimit_freq_zfit.ipynb): 
[demo_example.zip](https://github.com/user-attachments/files/19892742/demo_example.zip)

The fix addresses several points:
1) the change in the `frequentist_calculator` module: it's actually a fix on the theory level: to get the poinull test statistic distribution, you will want to evaluate the test statistic at the same point at which you generate (this is different for poialt). In https://arxiv.org/pdf/1007.1727 poinull is denoted as $\mu$, while poialt is denoted with $\mu^\prime$

2) the change on the other files have the following aim:
   The observation was that the toys thrown were always the same and corresponding to the original fit result given to the calculator. This is wrong. One wants the toys to correspond to the profile fit at the poigen value. So I had to
   a) set the starting parameters instead of the bestfit to the profile fit at the poigen value
   b) request that the distribution is thrown from a new loss every time

I put some plots up here, made with the demo example that I attached, which demonstrate that the fix works.
[clscurves.pdf](https://github.com/user-attachments/files/19892788/clscurves.pdf)
[massfit.pdf](https://github.com/user-attachments/files/19892795/massfit.pdf)
[q-distributions.pdf](https://github.com/user-attachments/files/19892800/q-distributions.pdf)
