### PR TITLE
Fix uploads of coverage tests, missed renamings master -> main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
   push:
-    branches: [ "master"]
+    branches: [ "main"]
   release:
     types:
       - "published"
@@ -108,7 +108,7 @@ jobs:
           touch docs/_build/html/.nojekyll
 
       - name: Deploy docs to GitHub Pages
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/getting_started/hypotests.rst
+++ b/docs/getting_started/hypotests.rst
@@ -137,4 +137,4 @@ In the result you obtain the observed and expected limits. The observed limit is
 of 4.518 +/- 5.8 signal candidates in data. The expected limit is the limit under the background only hypothesis.
 A graphical representation on how the upper limit is computed in shown in the following figure.
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/hepstats/master/notebooks/hypotests/asy_ul.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/hepstats/main/notebooks/hypotests/asy_ul.png

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -13,4 +13,4 @@ guide to each submodule:
     hypotests
     splot
 
-The `binder <https://mybinder.org/v2/gh/scikit-hep/hepstats/master>`_ examples are also a good way to get started.
+The `binder <https://mybinder.org/v2/gh/scikit-hep/hepstats/main>`_ examples are also a good way to get started.

--- a/docs/getting_started/modeling.rst
+++ b/docs/getting_started/modeling.rst
@@ -24,4 +24,4 @@ compared to a histogram of this sample with a fine binning.
     >>>          linewidth=2)
     >>> plt.legend(loc=2)
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/hepstats/master/notebooks/modeling/bayesian_blocks_example.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/hepstats/main/notebooks/modeling/bayesian_blocks_example.png

--- a/docs/getting_started/splot.rst
+++ b/docs/getting_started/splot.rst
@@ -1,7 +1,7 @@
 splot
 #####
 
-A full example using the **sPlot** algorithm can be found `here <https://github.com/scikit-hep/hepstats/tree/master/notebooks/splots/splot_example.ipynb>`_ . **sWeights** for different components in a data sample, modeled with a sum of extended probability density functions, are derived using the ``compute_sweights`` function:
+A full example using the **sPlot** algorithm can be found `here <https://github.com/scikit-hep/hepstats/tree/main/notebooks/splots/splot_example.ipynb>`_ . **sWeights** for different components in a data sample, modeled with a sum of extended probability density functions, are derived using the ``compute_sweights`` function:
 
 .. code-block:: python
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,6 @@
 # Notebooks
 
-In this directory are stored all the notebooks demo that you can either run with [binder](https://mybinder.org/v2/gh/scikit-hep/hepstats/master) or by downloading the jupyter notebooks `ipynb` files.
+In this directory are stored all the notebooks demo that you can either run with [binder](https://mybinder.org/v2/gh/scikit-hep/hepstats/main) or by downloading the jupyter notebooks `ipynb` files.
 
 The notebooks are divided for each `submodule`:
 - `hypotests`:
@@ -18,5 +18,5 @@ The notebooks are divided for each `submodule`:
     * bayesian_blocks.ipynb: presentation of the Bayesian Blocks algorithm and comparison with other binning methods.
 
 - `splots`
-    * splot_example.ipynb: example of `sPlot` on fake mass and momentum distributions for some signal and some background. The `sWeights` are derived using mass fit of a gaussian signal over an exponential background with `zfit`. The `sWeights` are applied on the momentum distribution to retrieve the signal distribution. This example is a reproduction of the example in [hep_ml](https://github.com/arogozhnikov/hep_ml/blob/master/notebooks/sPlot.ipynb) using `hepstats`.
+    * splot_example.ipynb: example of `sPlot` on fake mass and momentum distributions for some signal and some background. The `sWeights` are derived using mass fit of a gaussian signal over an exponential background with `zfit`. The `sWeights` are applied on the momentum distribution to retrieve the signal distribution. This example is a reproduction of the example in [hep_ml](https://github.com/arogozhnikov/hep_ml/blob/main/notebooks/sPlot.ipynb) using `hepstats`.
     * splot_example_2.ipynb: example of `sPlot` on fake mass and lifetime distributions for some signal and some background. The `sWeights` are derived using mass fit of a gaussian signal over an exponential background with `zfit`. The `sWeights` are applied on the lifetime distribution to retrieve the signal distribution. This example is a reproduction of the example of the [LHCb statistics guidelines](https://gitlab.cern.ch/lhcb/statistics-guidelines/-/blob/add_sweights_item/resources/appendix_f4.ipynb) using `hepstats`.

--- a/notebooks/hypotests/FC_interval_asy.ipynb
+++ b/notebooks/hypotests/FC_interval_asy.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "90 % CL intervals are evaluated for each $x_n$ for the two following cases, $\\mu > 0$ and $\\mu$ unbounded.\n",
     "\n",
-    "With `hepstats`, The intervals are obtained with `ConfidenceInterval` object using a calculator. Here the calculator is the `AsymptoticCalculator` which computes the intervals using asymptotic formulae (see [Asymptotic formulae for likelihood-based tests of new physics](https://arxiv.org/pdf/1007.1727.pdf)), an example of a 68 % CL interval with the `AsymptoticCalculator` can be found [here](https://github.com/scikit-hep/hepstats/blob/master/notebooks/hypotests/confidenceinterval_asy_zfit.ipynb).\n",
+    "With `hepstats`, The intervals are obtained with `ConfidenceInterval` object using a calculator. Here the calculator is the `AsymptoticCalculator` which computes the intervals using asymptotic formulae (see [Asymptotic formulae for likelihood-based tests of new physics](https://arxiv.org/pdf/1007.1727.pdf)), an example of a 68 % CL interval with the `AsymptoticCalculator` can be found [here](https://github.com/scikit-hep/hepstats/blob/main/notebooks/hypotests/confidenceinterval_asy_zfit.ipynb).\n",
     "\n",
     "The option `qtilde = True` should be used if $\\mu > 0$."
    ]

--- a/notebooks/hypotests/FC_interval_freq.ipynb
+++ b/notebooks/hypotests/FC_interval_freq.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "90 % CL intervals are evaluated for each $x_n$ for the two following cases, $\\mu > 0$ and $\\mu$ unbounded.\n",
     "\n",
-    "With `hepstats`, The intervals are obtained with `ConfidenceInterval` object using a calculator. Here the calculator is the `FrequentistCalculator` which computes the intervals using toys, an example of a 68 % CL interval with the `FrequentistCalculator` can be found [here](https://github.com/scikit-hep/hepstats/blob/master/notebooks/hypotests/confidenceinterval_freq_zfit.ipynb).\n",
+    "With `hepstats`, The intervals are obtained with `ConfidenceInterval` object using a calculator. Here the calculator is the `FrequentistCalculator` which computes the intervals using toys, an example of a 68 % CL interval with the `FrequentistCalculator` can be found [here](https://github.com/scikit-hep/hepstats/blob/main/notebooks/hypotests/confidenceinterval_freq_zfit.ipynb).\n",
     "\n",
     "The option `qtilde = True` should be used if $\\mu > 0$."
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hepstats"
-description = "statistics tools and utilities"
+description = "HEP statistics tools and utilities"
 authors = [{ name = "Matthieu Marinangeli", email = "matthieu.marinangeli@gmail.com" }]
 maintainers = [{ name = "Scikit-HEP", email = "scikit-hep-admins@googlegroups.com" }]
 license = { text = "BSD 3-Clause License" }

--- a/src/hepstats/hypotests/README.md
+++ b/src/hepstats/hypotests/README.md
@@ -1,6 +1,6 @@
 # Hypotests
 
-This submodule provides tools to do hypothesis tests such as discovery test and computations of upper limits or confidence intervals. hepstats needs a fitting backend to perform computations such as [zfit](https://github.com/zfit/zfit). Any fitting library can be used if their API is compatible with hepstats (see [api checks](https://github.com/scikit-hep/hepstats/blob/master/hepstats/hypotests/fitutils/api_check.py)).
+This submodule provides tools to do hypothesis tests such as discovery test and computations of upper limits or confidence intervals. hepstats needs a fitting backend to perform computations such as [zfit](https://github.com/zfit/zfit). Any fitting library can be used if their API is compatible with hepstats (see [api checks](https://github.com/scikit-hep/hepstats/blob/main/hepstats/hypotests/fitutils/api_check.py)).
 
 We give here a simple example of a discovery test, using the [zfit](https://github.com/zfit/zfit)
 fitting package as backend, of a Gaussian signal with known mean and sigma over an exponential background.


### PR DESCRIPTION
Hi @jonas-eschle, here are a few more fixes. I still see that the docs are not being deployed and also coverage settings were incorrect and I changed the default branch at https://app.codecov.io/gh/scikit-hep/hepstats/config/general to main. I also updated the CODECOV_TOKEN here in the settings. Let's see how that goes :-).