### PR TITLE
Be more explicit about minimum requirements on zfit for tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,12 +77,6 @@ repos:
     hooks:
       - id: jupyter-notebook-cleanup
 
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: 'v1.0'
-    hooks:
-      - id: upgrade-type-hints
-        args: [ '--futures=true' ]
-
 
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
     rev: v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,10 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-runner",
-    "zfit>=0.20.0;python_version<'3.13'",
+    "zfit>=0.27.0;python_version<'3.14'",
 #    'hepstats[zfit];python_version<"3.13"',  # not working, why?
 ]
-zfit = ["zfit>=0.20.0"]
+zfit = ["zfit>=0.27.0"]
 
 
 

--- a/src/hepstats/hypotests/calculators/asymptotic_calculator.py
+++ b/src/hepstats/hypotests/calculators/asymptotic_calculator.py
@@ -549,7 +549,6 @@ class AsymptoticCalculator(BaseCalculator):
 
         pnull = self.pnull(
             qobs=qobs,
-            qalt=qalt,
             onesided=onesided,
             qtilde=qtilde,
             onesideddiscovery=onesideddiscovery,
@@ -565,7 +564,6 @@ class AsymptoticCalculator(BaseCalculator):
         for ns in nsigma:
             p_clsb = self.pnull(
                 qobs=qalt,
-                qalt=None,
                 onesided=onesided,
                 qtilde=qtilde,
                 onesideddiscovery=onesideddiscovery,

--- a/src/hepstats/hypotests/calculators/frequentist_calculator.py
+++ b/src/hepstats/hypotests/calculators/frequentist_calculator.py
@@ -67,7 +67,6 @@ class FrequentistCalculator(ToysCalculator):
 
         Args:
             poinull: parameters of interest for the null hypothesis.
-            poialt: parameters of interest for the alternative hypothesis.
             onesided: if `True` computes onesided pvalues.
             onesideddiscovery: if `True` computes onesided pvalues for a discovery test.
             qtilde: if `True` use the :math:`\\widetilde{q}` test statistics else use the :math:`q`
@@ -79,7 +78,7 @@ class FrequentistCalculator(ToysCalculator):
         Example with **zfit**:
             >>> mean = zfit.Parameter("mu", 1.2)
             >>> poinull = POIarray(mean, [1.1, 1.2, 1.0])
-            >>> q = calc.qnull(poinull, poialt)
+            >>> q = calc.qnull(poinull)
         """
         toysresults = self.get_toys_null(poinull, poinull, qtilde)
         ret = {}

--- a/src/hepstats/hypotests/calculators/frequentist_calculator.py
+++ b/src/hepstats/hypotests/calculators/frequentist_calculator.py
@@ -59,7 +59,6 @@ class FrequentistCalculator(ToysCalculator):
     def qnull(
         self,
         poinull: POI | POIarray,
-        poialt: POI | None = None,
         onesided: bool = True,
         onesideddiscovery: bool = False,
         qtilde: bool = False,
@@ -80,7 +79,6 @@ class FrequentistCalculator(ToysCalculator):
         Example with **zfit**:
             >>> mean = zfit.Parameter("mu", 1.2)
             >>> poinull = POIarray(mean, [1.1, 1.2, 1.0])
-            >>> poialt = POI(mean, 1.2)
             >>> q = calc.qnull(poinull, poialt)
         """
         toysresults = self.get_toys_null(poinull, poinull, qtilde)


### PR DESCRIPTION
This now matches the in practice requirements for Python 3.10+ support from zfit. Better be explicit :).