### PR TITLE
Fix weighted inverse covariance calculation in sWeights

### DIFF
--- a/src/hepstats/splot/sweights.py
+++ b/src/hepstats/splot/sweights.py
@@ -109,7 +109,7 @@ def compute_sweights(model, x: np.ndarray, *, atol_exceptions: float | None = No
     Nx = eval_pdf(model, x, allow_extended=True)
     pN = p / Nx[:, None]
 
-    MLSR = pN.sum(axis=0)
+    MLSR = np.sum(sample_weight[:, None] * pN, axis=0)
     atol_warning = 5e-3
     if atol_exceptions is None:
         atol_exceptions = 5e-2
@@ -134,7 +134,7 @@ def compute_sweights(model, x: np.ndarray, *, atol_exceptions: float | None = No
         msg += " If the fit to the data is good please ignore this warning."
         warnings.warn(msg, AboveToleranceWarning, stacklevel=2)
 
-    Vinv = (pN).T.dot(pN)
+    Vinv = pN.T @ (sample_weight[:, None] * pN)
     V = np.linalg.inv(Vinv)
 
     sweights = p.dot(V) / Nx[:, None]

--- a/src/hepstats/splot/sweights.py
+++ b/src/hepstats/splot/sweights.py
@@ -120,10 +120,12 @@ def compute_sweights(
         sample_weight = np.asarray(sample_weight, dtype=float)
 
     if sample_weight.ndim != 1:
-        raise ValueError("sample_weight must be a 1D array.")
+        msg_0 = "sample_weight must be a 1D array."
+        raise ValueError(msg_0)
 
     if len(sample_weight) != pN.shape[0]:
-        raise ValueError("sample_weight must have the same length as x.")
+        msg_0 = "sample_weight must have the same length as x."
+        raise ValueError(msg_0)
     MLSR = np.sum(sample_weight[:, None] * pN, axis=0)
     atol_warning = 5e-3
     if atol_exceptions is None:

--- a/src/hepstats/splot/sweights.py
+++ b/src/hepstats/splot/sweights.py
@@ -26,7 +26,13 @@ def is_sum_of_extended_pdfs(model) -> bool:
     return all(m.is_extended for m in model.get_models()) and model.is_extended
 
 
-def compute_sweights(model, x: np.ndarray, *, atol_exceptions: float | None = None) -> dict[Any, np.ndarray]:
+def compute_sweights(
+    model,
+    x: np.ndarray,
+    *,
+    sample_weight: np.ndarray | None = None,
+    atol_exceptions: float | None = None,
+) -> dict[Any, np.ndarray]:
     """Computes sWeights from probability density functions for different components/species in a fit model
     (for instance signal and background) fitted on some data `x`.
 
@@ -108,7 +114,16 @@ def compute_sweights(model, x: np.ndarray, *, atol_exceptions: float | None = No
     p = np.vstack([eval_pdf(m, x) for m in models]).T
     Nx = eval_pdf(model, x, allow_extended=True)
     pN = p / Nx[:, None]
+    if sample_weight is None:
+        sample_weight = np.ones(pN.shape[0], dtype=float)
+    else:
+        sample_weight = np.asarray(sample_weight, dtype=float)
 
+    if sample_weight.ndim != 1:
+        raise ValueError("sample_weight must be a 1D array.")
+
+    if len(sample_weight) != pN.shape[0]:
+        raise ValueError("sample_weight must have the same length as x.")
     MLSR = np.sum(sample_weight[:, None] * pN, axis=0)
     atol_warning = 5e-3
     if atol_exceptions is None:

--- a/src/hepstats/splot/sweights.py
+++ b/src/hepstats/splot/sweights.py
@@ -41,6 +41,16 @@ def compute_sweights(
     Args:
         model: sum of extended pdfs.
         x: data on which `model` is fitted
+        sample_weight: Optional per-event weights used in the evaluation of the
+            Maximum Likelihood Sum Rule and inverse covariance matrix. If
+            provided, the inverse covariance matrix is computed as
+
+                Vinv = pN.T @ (sample_weight[:, None] * pN)
+
+            where ``pN`` contains the component PDFs divided by the total
+            extended PDF. If ``None``, the original unweighted calculation is
+            used. This can be useful when the fitted sample represents a
+            weighted distribution, for example in efficiency-corrected studies.
         atol_exceptions: absolute tolerance to check if the Maximum Likelihood Sum Rule sanity check,
             described in equation 17 of arXiv:physics/0402083, failed. Sum of yields should be 1 with
             an absolute tolerance of `atol_exceptions`.
@@ -115,18 +125,21 @@ def compute_sweights(
     Nx = eval_pdf(model, x, allow_extended=True)
     pN = p / Nx[:, None]
     if sample_weight is None:
-        sample_weight = np.ones(pN.shape[0], dtype=float)
+        MLSR = np.sum(pN, axis=0)
+        Vinv = pN.T.dot(pN)
     else:
         sample_weight = np.asarray(sample_weight, dtype=float)
 
-    if sample_weight.ndim != 1:
-        msg_0 = "sample_weight must be a 1D array."
-        raise ValueError(msg_0)
+        if sample_weight.ndim != 1:
+            msg_0 = "sample_weight must be a 1D array."
+            raise ValueError(msg_0)
 
-    if len(sample_weight) != pN.shape[0]:
-        msg_0 = "sample_weight must have the same length as x."
-        raise ValueError(msg_0)
-    MLSR = np.sum(sample_weight[:, None] * pN, axis=0)
+        if len(sample_weight) != pN.shape[0]:
+            msg_0 = "sample_weight must have the same length as x."
+            raise ValueError(msg_0)
+
+        MLSR = np.sum(sample_weight[:, None] * pN, axis=0)
+        Vinv = pN.T @ (sample_weight[:, None] * pN)
     atol_warning = 5e-3
     if atol_exceptions is None:
         atol_exceptions = 5e-2
@@ -151,7 +164,6 @@ def compute_sweights(
         msg += " If the fit to the data is good please ignore this warning."
         warnings.warn(msg, AboveToleranceWarning, stacklevel=2)
 
-    Vinv = pN.T @ (sample_weight[:, None] * pN)
     V = np.linalg.inv(Vinv)
 
     sweights = p.dot(V) / Nx[:, None]

--- a/tests/splots/test_splots.py
+++ b/tests/splots/test_splots.py
@@ -110,3 +110,30 @@ def test_sweights():
         compute_sweights(
             loss.model[0], np.concatenate([mass, np.random.normal(0.8, 0.1, 1000)])
         )
+
+def test_sweights_sample_weight_ones_matches_unweighted():
+    minimizer = Minuit()
+    mass, _, loss, Nsig, Nbkg, _, _ = get_data_and_loss()
+
+    result = minimizer.minimize(loss)
+    assert result.valid
+
+    model = loss.model[0]
+    sample_weight = np.ones_like(mass, dtype=float)
+
+    sweights_unweighted = compute_sweights(model, mass)
+    sweights_weighted = compute_sweights(model, mass, sample_weight=sample_weight)
+
+    for y in [Nsig, Nbkg]:
+        assert np.allclose(sweights_weighted[y], sweights_unweighted[y])
+
+
+def test_sweights_sample_weight_validation():
+    mass, _, loss, _, _, _, _ = get_data_and_loss()
+    model = loss.model[0]
+
+    with pytest.raises(ValueError, match="1D array"):
+        compute_sweights(model, mass, sample_weight=np.ones((mass.size, 1)))
+
+    with pytest.raises(ValueError, match="same length"):
+        compute_sweights(model, mass, sample_weight=np.ones(mass.size + 1))


### PR DESCRIPTION
This PR updates the computation of the inverse covariance matrix in `compute_sweights` when `sample_weight` is provided.

Previously, the matrix was evaluated as an unweighted event sum. For efficiency-weighted samples, this does not correspond to the desired weighted approximation of the integral entering the sWeight covariance matrix.

The change replaces the unweighted sum by a weighted matrix product,

    Vinv = pN.T @ (sample_weight[:, None] * pN)

where `pN` contains the component PDFs divided by the total extended model PDF. This makes the numerical evaluation consistent with the weighted sample used in the fit.

The default behaviour is unchanged when `sample_weight=None`.