### PR TITLE
Fix and improve coverage test command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           uv pip install --system -e .[test] pytest-xdist   # for multiprocessing, -e needed for pathes etc.
 
       - name: Test package
-        run: python -m pytest --doctest-modules --cov=hepstats --cov-report=xml -n auto
+        run: python -m pytest ./tests --doctest-modules --cov=src/hepstats --cov-report=xml -n auto
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,10 @@ jobs:
           uv pip install --system -e .[test] pytest-xdist   # for multiprocessing, -e needed for pathes etc.
 
       - name: Test package
-        run: python -m pytest ./tests --doctest-modules --cov=src/hepstats --cov-report=xml -n auto
+        run: python -m pytest ./tests --doctest-modules
+
+      - name: Test coverage with Codecov
+        run: python -m pytest ./tests --cov=src/hepstats --cov-report=xml
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Test package
         run: python -m pytest ./tests --doctest-modules --cov=src/hepstats --cov-report=xml -n auto
+        if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-runner",
-    "zfit>=0.20.0;python_version<'3.13'",
-#    'hepstats[zfit];python_version<"3.13"',  # not working, why?
+    # Only run the full set of tests for coverage, as it requires zfit in many places
+    "zfit>=0.20.0;python_version=='3.13'",
 ]
 zfit = ["zfit>=0.20.0"]
 


### PR DESCRIPTION
There were a couple of issues preventing a proper test of coverage to be performed, which explains why coverage was stated at the level of 4%, which in fact is only provided by tests that do not require zfit, which are a large minority.